### PR TITLE
Custom settings

### DIFF
--- a/README
+++ b/README
@@ -199,6 +199,17 @@ doesn't have the same name, so the update_classic_status.py script
 wouldn't be able to pick it up.
 
 
+Using Custom Settings
+---------------------
+
+You will need to modify settings.py to run layerindex-web in either development or production. As an example of development settings, you can use dev_settings.py. It uses SQLite3 as a database and a console backend for email, so that sent emails show up in your terminal rather than being sent anywhere.
+
+Then, to use these settings in with `manage.py`, do this:
+
+```bash
+python3 manage.py runserver --settings=dev_settings
+```
+
 
 Maintenance
 -----------

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -1,0 +1,22 @@
+import os
+import hashlib
+import random
+from settings import *
+
+WORKDIR = os.path.dirname(os.path.realpath(__file__))
+
+SECRET_KEY = hashlib.md5(str(random.random()).format(10).encode('utf-8')).hexdigest()
+
+DEBUG = True
+TEMPLATE_DEBUG = DEBUG
+
+ADMINS = (
+    ('admin', 'admin@example.com'),
+)
+
+DATABASES['default']['ENGINE'] = 'django.db.backends.sqlite3'
+DATABASES['default']['NAME'] = os.sep.join([WORKDIR, 'layerindex-sql'])
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+LAYER_FETCH_DIR = os.sep.join([WORKDIR, "layers"])


### PR DESCRIPTION
Adds a default 'dev_settings.py' profile that extends the 'settings.py' file to help contributors get a dev instance of the layer index up quickly. Also updates the readme to include details on using the dev settings.