### PR TITLE
views : add check for superusers in layer update notifications

### DIFF
--- a/layerindex/views.py
+++ b/layerindex/views.py
@@ -163,7 +163,7 @@ def edit_layer_view(request, template_name, branch='master', slug=None):
                     # Send email
                     plaintext = get_template('layerindex/submitemail.txt')
                     perm = Permission.objects.get(codename='publish_layer')
-                    users = User.objects.filter(Q(groups__permissions=perm) | Q(user_permissions=perm) ).distinct()
+                    users = User.objects.filter(Q(groups__permissions=perm) | Q(user_permissions=perm) | Q(is_superuser=True) ).distinct()
                     for user in users:
                         if user.first_name:
                             user_name = user.first_name


### PR DESCRIPTION
When a user submits a layer, notification emails are sent to users
with a certain permission. Superusers technically have all
permissions, but Q ignores them currently so that such emails
are not sent to superusers. This patch expands the check to
include superusers.

A few folks have discussed including this so I put this patch
up for consideration.